### PR TITLE
fix(docs): remove srv_record -> IPAddress outgoing relation

### DIFF
--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -56,7 +56,6 @@ The source of the data is useful in a number of different ways:
 | `ptr_record` | `FQDN` |
 | `mx_record` | `FQDN` |
 | `srv_record` | `FQDN` |
-| `srv_record` | `IPAddress` |
 
 ##### Incoming Relationships
 


### PR DESCRIPTION
This was a mistake from the original draft taxonomy