### PR TITLE
addition of url, port, and fingerprint

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -21,12 +21,16 @@ const (
 	Organization   AssetType = "Organization"
 	Registrar      AssetType = "Registrar"
 	Registrant     AssetType = "Registrant"
+	Port           AssetType = "Port"
+	URL            AssetType = "URL"
+	Fingerprint    AssetType = "Fingerprint"
 	TLSCertificate AssetType = "TLSCertificate"
 )
 
 var AssetList = []AssetType{
 	IPAddress, Netblock, ASN, RIROrg, FQDN, WHOIS, Location,
 	Phone, Email, Person, Organization, Registrar, Registrant,
+	Port, URL, Fingerprint, TLSCertificate,
 }
 
 var locationRels = map[string][]AssetType{}
@@ -69,6 +73,7 @@ var personRels = map[string][]AssetType{
 	"phone_number":  {Phone},
 	"email_address": {Email},
 	"location":      {Location},
+	"url":           {URL},
 }
 
 var orgRels = map[string][]AssetType{
@@ -85,7 +90,10 @@ var registrarRels = map[string][]AssetType{
 	"whois_server": {FQDN},
 }
 
-var ipRels = map[string][]AssetType{}
+var ipRels = map[string][]AssetType{
+	"url":  {URL},
+	"port": {Port},
+}
 
 var netblockRels = map[string][]AssetType{
 	"contains": {IPAddress},
@@ -108,6 +116,7 @@ var fqdnRels = map[string][]AssetType{
 	"srv_record":   {FQDN, IPAddress},
 	"node":         {FQDN},
 	"registration": {WHOIS},
+	"url":          {URL},
 }
 
 var tlscertRels = map[string][]AssetType{
@@ -137,7 +146,16 @@ var tlscertRels = map[string][]AssetType{
 	"policies":                  {TLSCertificate},
 	"subject_key_id":            {TLSCertificate},
 	"authority_key_id":          {TLSCertificate},
+	"jarm":                      {Fingerprint},
 }
+
+var portRels = map[string][]AssetType{}
+
+var urlRels = map[string][]AssetType{
+	"port": {Port},
+}
+
+var fingerprintRels = map[string][]AssetType{}
 
 // ValidRelationship returns true if the relation is valid in the taxonomy
 // when outgoing from the source asset type to the destination asset type.
@@ -171,6 +189,12 @@ func ValidRelationship(source AssetType, relation string, destination AssetType)
 		relations = registrarRels
 	case TLSCertificate:
 		relations = tlscertRels
+	case Port:
+		relations = portRels
+	case URL:
+		relations = urlRels
+	case Fingerprint:
+		relations = fingerprintRels
 	default:
 		return false
 	}

--- a/asset_test.go
+++ b/asset_test.go
@@ -35,6 +35,9 @@ func TestAssetTypeConstants(t *testing.T) {
 		Organization,
 		Registrar,
 		Registrant,
+		Port,
+		URL,
+		Fingerprint,
 		TLSCertificate,
 	}
 
@@ -52,6 +55,9 @@ func TestAssetTypeConstants(t *testing.T) {
 		"Organization",
 		"Registrar",
 		"Registrant",
+		"Port",
+		"URL",
+		"Fingerprint",
 		"TLSCertificate",
 	}
 

--- a/contact/email_address.go
+++ b/contact/email_address.go
@@ -8,8 +8,8 @@ import (
 
 // EmailAddress represents an email address with a value, local part, and domain.
 type EmailAddress struct {
-	// Value is the full email address.
-	Value string `json:"value"`
+	// Address is the full email address.
+	Address string `json:"address"`
 	// LocalPart is the part of the email address before the "@" symbol.
 	LocalPart string `json:"local_part"`
 	// Domain is the part of the email address after the "@" symbol.

--- a/contact/email_address_test.go
+++ b/contact/email_address_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestEmailAddress_AssetType(t *testing.T) {
 	e := EmailAddress{
-		Value:     "test@example.com",
+		Address:   "test@example.com",
 		LocalPart: "test",
 		Domain:    "example.com",
 	}
@@ -22,12 +22,12 @@ func TestEmailAddress_AssetType(t *testing.T) {
 
 func TestEmailAddress_JSON(t *testing.T) {
 	e := EmailAddress{
-		Value:     "test@example.com",
+		Address:   "test@example.com",
 		LocalPart: "test",
 		Domain:    "example.com",
 	}
 
-	expectedJSON := `{"value":"test@example.com","local_part":"test","domain":"example.com"}`
+	expectedJSON := `{"address":"test@example.com","local_part":"test","domain":"example.com"}`
 
 	jsonBytes, err := e.JSON()
 	if err != nil {
@@ -45,6 +45,6 @@ func TestEmailAddress_JSON(t *testing.T) {
 	}
 
 	if unmarshaled != e {
-		t.Errorf("Expected unmarshaled value %v, got %v", e, unmarshaled)
+		t.Errorf("Expected unmarshaled address %v, got %v", e, unmarshaled)
 	}
 }

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -1,0 +1,23 @@
+package fingerprint
+
+import (
+	"encoding/json"
+
+	model "github.com/owasp-amass/open-asset-model"
+)
+
+// Fingerprint represents a fingerprint.
+type Fingerprint struct {
+	String string `json:"string"` // Fingerprint string
+	Type   string `json:"type"`   // Fingerprint type
+}
+
+// AssetType returns the asset type.
+func (f Fingerprint) AssetType() model.AssetType {
+	return model.Fingerprint
+}
+
+// JSON returns the JSON encoding of the struct.
+func (f Fingerprint) JSON() ([]byte, error) {
+	return json.Marshal(f)
+}

--- a/fingerprint/fingerprint_test.go
+++ b/fingerprint/fingerprint_test.go
@@ -1,0 +1,42 @@
+package fingerprint_test
+
+import (
+	"testing"
+
+	model "github.com/owasp-amass/open-asset-model"
+	"github.com/owasp-amass/open-asset-model/fingerprint"
+)
+
+func TestFingerprint_AssetType(t *testing.T) {
+	fp := fingerprint.Fingerprint{
+		String: "example",
+		Type:   "example",
+	}
+	want := model.Fingerprint
+
+	if got := fp.AssetType(); got != want {
+		t.Errorf("Fingerprint.AssetType() = %v, want %v", got, want)
+	}
+}
+
+func TestFingerprint_JSON(t *testing.T) {
+	fp := fingerprint.Fingerprint{
+		String: "example",
+		Type:   "example",
+	}
+
+	// Test AssetType method
+	if fp.AssetType() != model.Fingerprint {
+		t.Errorf("Expected asset type %s, but got %s", model.Fingerprint, fp.AssetType())
+	}
+
+	// Test JSON method
+	expectedJSON := `{"string":"example","type":"example"}`
+	jsonData, err := fp.JSON()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if string(jsonData) != expectedJSON {
+		t.Errorf("Expected JSON %s, but got %s", expectedJSON, string(jsonData))
+	}
+}

--- a/network/port.go
+++ b/network/port.go
@@ -1,0 +1,24 @@
+package network
+
+import (
+	"encoding/json"
+
+	model "github.com/owasp-amass/open-asset-model"
+)
+
+type Port struct {
+	// Number is the port number.
+	Number int `json:"number"`
+	// Protocol is the protocol of the port, such as "tcp" or "udp".
+	Protocol string `json:"protocol"`
+}
+
+// AssetType returns the asset type.
+func (p Port) AssetType() model.AssetType {
+	return model.Port
+}
+
+// JSON returns the JSON encoding of the struct.
+func (p Port) JSON() ([]byte, error) {
+	return json.Marshal(p)
+}

--- a/network/port_test.go
+++ b/network/port_test.go
@@ -1,0 +1,39 @@
+package network_test
+
+import (
+	"testing"
+
+	model "github.com/owasp-amass/open-asset-model"
+	"github.com/owasp-amass/open-asset-model/network"
+)
+
+func TestPort_AssetType(t *testing.T) {
+	p := network.Port{}
+	want := model.Port
+
+	if got := p.AssetType(); got != want {
+		t.Errorf("Port.AssetType() = %v, want %v", got, want)
+	}
+}
+
+func TestPort_JSON(t *testing.T) {
+	p := network.Port{
+		Number:   80,
+		Protocol: "tcp",
+	}
+
+	// Test AssetType method
+	if p.AssetType() != model.Port {
+		t.Errorf("Expected asset type %s, but got %s", model.Port, p.AssetType())
+	}
+
+	// Test JSON method
+	expectedJSON := `{"number":80,"protocol":"tcp"}`
+	json, err := p.JSON()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if string(json) != expectedJSON {
+		t.Errorf("Expected JSON %s, but got %s", expectedJSON, string(json))
+	}
+}

--- a/url/url.go
+++ b/url/url.go
@@ -1,0 +1,41 @@
+package url
+
+import (
+	"bytes"
+	"encoding/json"
+
+	model "github.com/owasp-amass/open-asset-model"
+)
+
+// URL represents a URL.
+type URL struct {
+	Raw      string `json:"url"`                // Raw, unprocessed URL
+	Scheme   string `json:"scheme"`             // Scheme (http, https)
+	Username string `json:"username,omitempty"` // Username for authentication
+	Password string `json:"password,omitempty"` // Password for authentication
+	Host     string `json:"host"`               // Host
+	Port     int    `json:"port,omitempty"`     // Port
+	Path     string `json:"path"`               // Name
+	Options  string `json:"options,omitempty"`  // Extra options used while connecting
+	Fragment string `json:"fragment,omitempty"` // Fragment used in URI
+}
+
+// AssetType returns the asset type.
+func (u URL) AssetType() model.AssetType {
+	return model.URL
+}
+
+// JSON returns the JSON encoding of the struct.
+func (u URL) JSON() ([]byte, error) {
+	buffer := new(bytes.Buffer)
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+
+	err := encoder.Encode(u)
+	if err != nil {
+		return nil, err
+	}
+
+	// Trim the newline added by the encoder
+	return bytes.TrimRight(buffer.Bytes(), "\n"), nil
+}

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -1,0 +1,47 @@
+package url_test
+
+import (
+	"testing"
+
+	model "github.com/owasp-amass/open-asset-model"
+	"github.com/owasp-amass/open-asset-model/url"
+)
+
+func TestURL_AssetType(t *testing.T) {
+	u := url.URL{}
+	want := model.URL
+
+	if got := u.AssetType(); got != want {
+		t.Errorf("URL.AssetType() = %v, want %v", got, want)
+	}
+}
+
+func TestURL_JSON(t *testing.T) {
+	u := url.URL{
+		Raw:      "http://user:pass@example.com:8080/path?option1=value1&option2=value2#fragment",
+		Scheme:   "http",
+		Username: "user",
+		Password: "pass",
+		Host:     "example.com",
+		Port:     8080,
+		Path:     "/path",
+		Options:  "option1=value1&option2=value2",
+		Fragment: "fragment",
+	}
+
+	// Test AssetType method
+	if u.AssetType() != model.URL {
+		t.Errorf("Expected asset type %s, but got %s", model.URL, u.AssetType())
+	}
+
+	// Test JSON method
+	expectedJSON := `{"url":"http://user:pass@example.com:8080/path?option1=value1&option2=value2#fragment","scheme":"http","username":"user","password":"pass","host":"example.com","port":8080,"path":"/path","options":"option1=value1&option2=value2","fragment":"fragment"}`
+	json, err := u.JSON()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	t.Log(string(json))
+	if string(json) != expectedJSON {
+		t.Errorf("Expected JSON %s, but got %s", expectedJSON, string(json))
+	}
+}

--- a/whois/whois.go
+++ b/whois/whois.go
@@ -11,6 +11,18 @@ type WHOIS struct {
 	// Type represents the type of the WHOIS information.
 	Type string `json:"type"`
 
+	// Registrar represents the registrar of a domain name.
+	Registrar string `json:"registrar,omitempty"`
+
+	// Domain represents the domain name.
+	Domain string `json:"domain,omitempty"`
+
+	// Reseller represents the reseller of the domain.
+	Reseller string `json:"reseller,omitempty"`
+
+	// NameServers represents the name servers of the domain.
+	NameServers []string `json:"name_servers,omitempty"`
+
 	// CreatedDate represents the creation date of the domain or org associated with a netblock.
 	CreatedDate string `json:"created_date,omitempty"`
 
@@ -26,17 +38,83 @@ type WHOIS struct {
 	// RegistryRegistrantID represents the registry registrant ID of the domain.
 	RegistryRegistrantID string `json:"registry_registrant_id,omitempty"`
 
+	// RegistryRegistrantName represents the registry registrant name of the domain.
+	RegistryRegistrantName string `json:"registry_registrant_name,omitempty"`
+
+	// RegistryRegistrantOrg represents the registry registrant org of the domain.
+	RegistryRegistrantOrg string `json:"registry_registrant_org,omitempty"`
+
+	// RegistryRegistrantLocation represents the registry registrant location of the domain.
+	RegistryRegistrantLocation string `json:"registry_registrant_location,omitempty"`
+
+	// RegistryRegistrantPhone represents the registry registrant phone of the domain.
+	RegistryRegistrantPhone string `json:"registry_registrant_phone,omitempty"`
+
+	// RegistryRegistrantFax represents the registry registrant fax of the domain.
+	RegistryRegistrantFax string `json:"registry_registrant_fax,omitempty"`
+
+	// RegistryRegistrantEmail represents the registry registrant email of the domain.
+	RegistryRegistrantEmail string `json:"registry_registrant_email,omitempty"`
+
 	// RegistryDomainID represents the registry domain ID of the domain.
 	RegistryDomainID string `json:"registry_domain_id,omitempty"`
 
 	// RegistryBillingID represents the registry billing ID of the domain.
 	RegistryBillingID string `json:"registry_billing_id,omitempty"`
 
+	// RegistryBillingName represents the registry billing name of the domain.
+	RegistryBillingName string `json:"registry_billing_name,omitempty"`
+
+	// RegistryBillingOrg represents the registry billing org of the domain.
+	RegistryBillingOrg string `json:"registry_billing_org,omitempty"`
+
+	// RegistryBillingLocation represents the registry billing location of the domain.
+	RegistryBillingLocation string `json:"registry_billing_location,omitempty"`
+
+	// RegistryBillingEmail represents the registry billing email of the domain.
+	RegistryBillingEmail string `json:"registry_billing_email,omitempty"`
+
 	// RegistryAdminID represents the registry admin ID of the domain.
 	RegistryAdminID string `json:"registry_admin_id,omitempty"`
 
+	// RegistryAdminName represents the registry admin name of the domain.
+	RegistryAdminName string `json:"registry_admin_name,omitempty"`
+
+	// RegistryAdminOrg represents the registry admin org of the domain.
+	RegistryAdminOrg string `json:"registry_admin_org,omitempty"`
+
+	// RegistryAdminLocation represents the registry admin location of the domain.
+	RegistryAdminLocation string `json:"registry_admin_location,omitempty"`
+
+	// RegistryAdminPhone represents the registry admin phone of the domain.
+	RegistryAdminPhone string `json:"registry_admin_phone,omitempty"`
+
+	// RegistryAdminFax represents the registry admin fax of the domain.
+	RegistryAdminFax string `json:"registry_admin_fax,omitempty"`
+
+	// RegistryAdminEmail represents the registry admin email of the domain.
+	RegistryAdminEmail string `json:"registry_admin_email,omitempty"`
+
 	// RegistryTechID represents the registry tech ID of the domain.
 	RegistryTechID string `json:"registry_tech_id,omitempty"`
+
+	// RegistryTechName represents the registry tech name of the domain.
+	RegistryTechName string `json:"registry_tech_name,omitempty"`
+
+	// RegistryTechOrg represents the registry tech org of the domain.
+	RegistryTechOrg string `json:"registry_tech_org,omitempty"`
+
+	// RegistryTechLocation represents the registry tech location of the domain.
+	RegistryTechLocation string `json:"registry_tech_location,omitempty"`
+
+	// RegistryTechPhone represents the registry tech phone of the domain.
+	RegistryTechPhone string `json:"registry_tech_phone,omitempty"`
+
+	// RegistryTechFax represents the registry tech fax of the domain.
+	RegistryTechFax string `json:"registry_tech_fax,omitempty"`
+
+	// RegistryTechEmail represents the registry tech email of the domain.
+	RegistryTechEmail string `json:"registry_tech_email,omitempty"`
 
 	// Description represents the description of the domain or org associated with a netblock.
 	Description string `json:"description,omitempty"`

--- a/whois/whois_test.go
+++ b/whois/whois_test.go
@@ -15,21 +15,46 @@ func TestWHOIS_AssetType(t *testing.T) {
 		t.Errorf("WHOIS.AssetType() = %v, want %v", got, want)
 	}
 }
-
 func TestWHOIS(t *testing.T) {
 	whois := WHOIS{
-		Type:                 "domain",
-		CreatedDate:          "2020-01-01",
-		UpdatedDate:          "2021-01-01",
-		ExpirationDate:       "2022-01-01",
-		DomainStatus:         []string{"active", "clientTransferProhibited"},
-		RegistryRegistrantID: "12345",
-		RegistryDomainID:     "67890",
-		RegistryBillingID:    "13579",
-		RegistryAdminID:      "24680",
-		RegistryTechID:       "13579",
-		Description:          "Example domain",
-		DNSSEC:               "unsigned",
+		Type:                       "domain",
+		Registrar:                  "Registrar",
+		Domain:                     "example.com",
+		Reseller:                   "Reseller",
+		NameServers:                []string{"NameServer1", "NameServer2"},
+		CreatedDate:                "2020-01-01",
+		UpdatedDate:                "2021-01-01",
+		ExpirationDate:             "2022-01-01",
+		DomainStatus:               []string{"active", "clientTransferProhibited"},
+		RegistryRegistrantID:       "12345",
+		RegistryRegistrantName:     "RegistryRegistrantName",
+		RegistryRegistrantOrg:      "RegistryRegistrantOrg",
+		RegistryRegistrantLocation: "RegistryRegistrantLocation",
+		RegistryRegistrantPhone:    "RegistryRegistrantPhone",
+		RegistryRegistrantFax:      "RegistryRegistrantFax",
+		RegistryRegistrantEmail:    "RegistryRegistrantEmail",
+		RegistryDomainID:           "67890",
+		RegistryBillingID:          "13579",
+		RegistryBillingName:        "RegistryBillingName",
+		RegistryBillingOrg:         "RegistryBillingOrg",
+		RegistryBillingLocation:    "RegistryBillingLocation",
+		RegistryBillingEmail:       "RegistryBillingEmail",
+		RegistryAdminID:            "24680",
+		RegistryAdminName:          "RegistryAdminName",
+		RegistryAdminOrg:           "RegistryAdminOrg",
+		RegistryAdminLocation:      "RegistryAdminLocation",
+		RegistryAdminPhone:         "RegistryAdminPhone",
+		RegistryAdminFax:           "RegistryAdminFax",
+		RegistryAdminEmail:         "RegistryAdminEmail",
+		RegistryTechID:             "13579",
+		RegistryTechName:           "RegistryTechName",
+		RegistryTechOrg:            "RegistryTechOrg",
+		RegistryTechLocation:       "RegistryTechLocation",
+		RegistryTechPhone:          "RegistryTechPhone",
+		RegistryTechFax:            "RegistryTechFax",
+		RegistryTechEmail:          "RegistryTechEmail",
+		Description:                "Example domain",
+		DNSSEC:                     "unsigned",
 	}
 
 	// Test AssetType method
@@ -38,7 +63,7 @@ func TestWHOIS(t *testing.T) {
 	}
 
 	// Test JSON method
-	expectedJSON := `{"type":"domain","created_date":"2020-01-01","updated_date":"2021-01-01","expiration_date":"2022-01-01","domain_status":["active","clientTransferProhibited"],"registry_registrant_id":"12345","registry_domain_id":"67890","registry_billing_id":"13579","registry_admin_id":"24680","registry_tech_id":"13579","description":"Example domain","dnssec":"unsigned"}`
+	expectedJSON := `{"type":"domain","registrar":"Registrar","domain":"example.com","reseller":"Reseller","name_servers":["NameServer1","NameServer2"],"created_date":"2020-01-01","updated_date":"2021-01-01","expiration_date":"2022-01-01","domain_status":["active","clientTransferProhibited"],"registry_registrant_id":"12345","registry_registrant_name":"RegistryRegistrantName","registry_registrant_org":"RegistryRegistrantOrg","registry_registrant_location":"RegistryRegistrantLocation","registry_registrant_phone":"RegistryRegistrantPhone","registry_registrant_fax":"RegistryRegistrantFax","registry_registrant_email":"RegistryRegistrantEmail","registry_domain_id":"67890","registry_billing_id":"13579","registry_billing_name":"RegistryBillingName","registry_billing_org":"RegistryBillingOrg","registry_billing_location":"RegistryBillingLocation","registry_billing_email":"RegistryBillingEmail","registry_admin_id":"24680","registry_admin_name":"RegistryAdminName","registry_admin_org":"RegistryAdminOrg","registry_admin_location":"RegistryAdminLocation","registry_admin_phone":"RegistryAdminPhone","registry_admin_fax":"RegistryAdminFax","registry_admin_email":"RegistryAdminEmail","registry_tech_id":"13579","registry_tech_name":"RegistryTechName","registry_tech_org":"RegistryTechOrg","registry_tech_location":"RegistryTechLocation","registry_tech_phone":"RegistryTechPhone","registry_tech_fax":"RegistryTechFax","registry_tech_email":"RegistryTechEmail","description":"Example domain","dnssec":"unsigned"}`
 	json, err := whois.JSON()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
This commit adds the following to OAM:

1. Port # 
2. URL
3. Fingerprint (open to changes in the `String` variable name, not exactly sure what's most appropriate name)

relations are added in asset.go as well, specifically:

- person -> URL (personal website?? open to removal)
- IP -> port
- IP -> URL (URLs can contain ips, not just FQDNs)
- FQDN -> URL
- TLS -> Fingerprint (JARM)
- URL -> port (URLs can contain port # )